### PR TITLE
Handle nullable product prices and fix seed

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -8,8 +8,8 @@ interface Props {
     name: string;
     slug: string;
     images: string[];
-    price?: number;
-    rating?: number;
+    price?: number | null;
+    rating?: number | null;
   };
 }
 
@@ -22,8 +22,8 @@ export default function ProductCard({ product }: Props) {
       <h3 className="text-lg font-semibold mt-2">
         <Link href={`/products/${product.slug}`}>{product.name}</Link>
       </h3>
-      {product.rating && <RatingStars rating={product.rating} />}
-      {product.price && <PriceTag price={product.price} />}
+      {product.rating != null && <RatingStars rating={product.rating} />}
+      {product.price != null && <PriceTag price={product.price} />}
     </div>
   );
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -98,7 +98,7 @@ async function main() {
         slug: p.title.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
         content: `<p>${p.title} Inhalt...</p>`,
         status: 'PUBLISHED',
-        authorId: admin.id,
+        author: { connect: { id: admin.id } },
         category: { connect: { name: p.category } },
         publishedAt: new Date(),
       },
@@ -106,9 +106,10 @@ async function main() {
   }
 
   await prisma.comparison.upsert({
-    where: { title: 'Beste Drohnen 2025: Einsteiger bis Pro' },
+    where: { id: 'comparison-1' },
     update: {},
     create: {
+      id: 'comparison-1',
       title: 'Beste Drohnen 2025: Einsteiger bis Pro',
       products: { connect: products.map((p) => ({ slug: p.slug })) },
       verdict: 'Alle Drohnen getestet',


### PR DESCRIPTION
## Summary
- allow product cards to handle null price and rating values
- correct Prisma seed data to link author and comparison records by IDs

## Testing
- `npm test`
- `npm run lint`
- `npm run e2e` *(fails: Cannot find module '@playwright/test')*
- `npm run build` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_689b7b2230908327804241dd153697e1